### PR TITLE
Add documentation for energy meters and mark unused sensors as internal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ The blueprint currently creates the following sersors for use in Home Assistant.
 
 | Name | Unit |
 | --- | --- |
-| Cumulative Active Import | kWh|
+| Cumulative Active Import | kWh |
+| Cumulative Active Import | energy |
 | Cumulative_active_export | kWh |
+| Cumulative_active_export | energy |
 | Cumulative_Reactive_Import |kvarh |
 | Cumulative_reactive_export | kvarh |
 | Effect | kW |

--- a/README.md
+++ b/README.md
@@ -8,30 +8,28 @@ The blueprint currently creates the following sersors for use in Home Assistant.
 | Name | Unit |
 | --- | --- |
 | Cumulative Active Import | kWh |
-| Cumulative Active Import | energy |
-| Cumulative_active_export | kWh |
-| Cumulative_active_export | energy |
-| Cumulative_Reactive_Import |kvarh |
-| Cumulative_reactive_export | kvarh |
+| Cumulative Active Export | kWh |
+| Cumulative Reactive Import |kvarh |
+| Cumulative Reactive Export | kvarh |
 | Effect | kW |
-| Momentary_active_export | kW |
-| Momentary_reactive_import |kvar |
-| Momentary_reactive_export | kvar |
+| Momentary Active Export | kW |
+| Momentary Reactive Import |kvar |
+| Momentary Reactive Export | kvar |
 | Effect Phase 1 | kW |
-| Momentary_active_export_phase_1 | kW |
+| Momentary Active Export Phase_1 | kW |
 | Effect Phase 2 | kW |
-| Momentary_active_export_phase_2 | kW |
+| Momentary Active Export Phase_2 | kW |
 | Effect Phase 3 | kW |
-| Momentary_active_export_phase_3 | kW |
-| Momentary_Reactive_Import_Phase_1 |kvar |
-| Momentary_reactive_export_phase_1 |kvar |
-| Momentary_Reactive_Import_Phase_2 |kvar |
-| Momentary_reactive_export_phase_2 |kvar |
-| Momentary_Reactive_Import_Phase_3 |kvar | 
-| Momentary_reactive_export_phase_3 |kvar |
-| Voltage Phase 1 |V |
-| Voltage Phase 2 |V |
+| Momentary Active Export Phase_3 | kW |
+| Momentary Reactive Import_Phase_1 | kvar |
+| Momentary Reactive Export_phase_1 | kvar |
+| Momentary Reactive Import_Phase_2 | kvar |
+| Momentary Reactive Export_phase_2 | kvar |
+| Momentary Reactive Import_Phase_3 | kvar | 
+| Momentary Reactive Export_phase_3 | kvar |
+| Voltage Phase 1 | V |
+| Voltage Phase 2 | V |
 | Voltage Phase 3 | V |
 | Current Phase 1 | A |
 | Current Phase 2 | A |
-| Current Phase 3 |A |
+| Current Phase 3 | A |

--- a/elmatare.yaml
+++ b/elmatare.yaml
@@ -104,11 +104,12 @@ sensor:
     state_class: "total_increasing"
     device_class: "energy"
     internal: true
-  - id: "Cumulative_Reactive_Import"
+  - name: "Cumulative Reactive Import"
+    id: "cumulative_reactive_import"
     unit_of_measurement: kvarh
     accuracy_decimals: 3
     internal: true
-- name: "Cumulative Reactive Export"
+  - name: "Cumulative Reactive Export"
     id: "cumulative_reactive_export"
     unit_of_measurement: kvarh
     accuracy_decimals: 3

--- a/elmatare.yaml
+++ b/elmatare.yaml
@@ -107,7 +107,8 @@ sensor:
   - id: "Cumulative_Reactive_Import"
     unit_of_measurement: kvarh
     accuracy_decimals: 3
-  - name: "Cumulative Reactive Export"
+    internal: true
+- name: "Cumulative Reactive Export"
     id: "cumulative_reactive_export"
     unit_of_measurement: kvarh
     accuracy_decimals: 3

--- a/elmatare.yaml
+++ b/elmatare.yaml
@@ -1,3 +1,4 @@
+---
 esphome:
   name: elmatare
   platform: ESP8266
@@ -96,69 +97,100 @@ sensor:
     accuracy_decimals: 3
     state_class: "total_increasing"
     device_class: "energy"
-  - id: "cumulative_active_export"
+  - name: "Cumulative Active Import" 
+    id: "cumulative_active_export"
     unit_of_measurement: kWh
     accuracy_decimals: 3
     state_class: "total_increasing"
     device_class: "energy"
+    internal: true
   - id: "Cumulative_Reactive_Import"
     unit_of_measurement: kvarh
     accuracy_decimals: 3
-  - id: "cumulative_reactive_export"
+  - name: "Cumulative Reactive Export"
+    id: "cumulative_reactive_export"
     unit_of_measurement: kvarh
     accuracy_decimals: 3
+    internal: true
   - name: "Effect"
     id: my_power
     unit_of_measurement: kW
     accuracy_decimals: 3
-  - id: "momentary_active_export"
+    internal: false
+  - name: "Momentary Active Export"
+    id: "momentary_active_export"
     unit_of_measurement: kW
     accuracy_decimals: 3
-  - id: "momentary_reactive_import"
+    internal: true
+  - name: "Momentary Reactive Import"
+    id: "momentary_reactive_import"
     unit_of_measurement: kvar
     accuracy_decimals: 3
-  - id: "momentary_reactive_export"
+    internal: true
+  - name: "Momentary Reactive Export"
+    id: "momentary_reactive_export"
     unit_of_measurement: kvar
     accuracy_decimals: 3
+    internal: true
   - name: "Effect Phase 1"
     id: my_power_p1
     unit_of_measurement: kW
     accuracy_decimals: 3
-  - id: "momentary_active_export_phase_1"
+    internal: false
+  - name: "Momentary Active Export Phase 1"
+    id: "momentary_active_export_phase_1"
     unit_of_measurement: kW
     accuracy_decimals: 3
   - name: "Effect Phase 2"
     id: my_power_p2
     unit_of_measurement: kW
     accuracy_decimals: 3
-  - id: "momentary_active_export_phase_2"
+    internal: false
+  - name: "Momentary Active Export Phase 2"
+    id: "momentary_active_export_phase_2"
     unit_of_measurement: kW
     accuracy_decimals: 3
+    internal: true
   - name: "Effect Phase 3"
     id: my_power_p3
     unit_of_measurement: kW
     accuracy_decimals: 3
-  - id: "momentary_active_export_phase_3"
+    internal: false
+ -  name: "Momentary Active Export Phase 3"
+    id: "momentary_active_export_phase_3"
     unit_of_measurement: kW
     accuracy_decimals: 3
-  - id: "Momentary_Reactive_Import_Phase_1"
+    internal: true
+  - name: "Momentary Reactive Import Phase 1"
+    id: "momentary_reactive_import_phase_1"
     unit_of_measurement: kvar
     accuracy_decimals: 3
-  - id: "momentary_reactive_export_phase_1"
+    internal: true
+  - name: "Momentary Reactive Export Phase 1"
+    id: "momentary_reactive_export_phase_1"
     unit_of_measurement: kvar
     accuracy_decimals: 3
-  - id: "Momentary_Reactive_Import_Phase_2"
+    internal: true
+  - name: "Momentary Reactive Import Phase 2"
+    id: "momentary_reactive_import_phase_2"
     unit_of_measurement: kvar
     accuracy_decimals: 3
-  - id: "momentary_reactive_export_phase_2"
+    internal: true
+  - name: "Momentary Reactive Export Phase 2"
+    id: "momentary_reactive_export_phase_2"
     unit_of_measurement: kvar
     accuracy_decimals: 3
-  - id: "Momentary_Reactive_Import_Phase_3"
+    internal: true
+  - name: "Momentary Reactive Import Phase 3"
+    id: "momentary_reactive_import_phase_3"
     unit_of_measurement: kvar
     accuracy_decimals: 3
-  - id: "momentary_reactive_export_phase_3"
+    internal: true
+  - name: "Momentary Reactive Export Phase 3"
+    id: "momentary_reactive_export_phase_3"
     unit_of_measurement: kvar
     accuracy_decimals: 3
+    internal: true
   - name: "Voltage Phase 1"
     unit_of_measurement: V
     accuracy_decimals: 3


### PR DESCRIPTION
- Adds energy sensors to the documentation.
- Change all id variables to be lower case.
- Add 'internal: true' and 'internal: false' to sensors that are either hidden or used both internally and externally.